### PR TITLE
CDP-735: Add a "web" and "broadcast" dropdown to the video feeder

### DIFF
--- a/admin/metaboxes/videos.php
+++ b/admin/metaboxes/videos.php
@@ -22,6 +22,7 @@ $video = $videos->add_field( array(
   ),
 ) );
 
+
 $videos->add_group_field($video, array(
   'name' => 'Video File',
   'desc' => 'Upload a video file if you would like it downloadable.',
@@ -43,6 +44,20 @@ $videos->add_group_field($video, array(
 ));
 
 $videos->add_group_field($video, array(
+  'name'             => 'Video Quality',
+  'desc'             => 'Will this be used for web or broadcast?',
+  'id'               => $prefix . 'videos_video_quality',
+  'type'             => 'select',
+  'default'          => '',
+  'options'          => array(
+    '' => '',
+    'web' => __( 'Web', 'cdp-video-post-type' ),
+    'broadcast'   => __( 'Broadcast', 'cdp-video-post-type' ),
+  ),
+  'attributes' => ['required' => 'required']
+) );
+
+$videos->add_group_field($video, array(
   'name' => 'YouTube URL',
   'desc' => 'Enter a YouTube streaming URL.',
   'id' => $prefix . 'videos_video_streaming_url',
@@ -62,4 +77,3 @@ $videos->add_group_field($video, array(
 ) );
 
 Cdp_Video_Post_Type_Admin_Helpers::cmb2_video_post_type_language_metabox($videos, $video, $prefix . 'videos_video_language');
-?>

--- a/includes/class-cdp-video-post-type-rest-controller.php
+++ b/includes/class-cdp-video-post-type-rest-controller.php
@@ -97,6 +97,8 @@ if (is_plugin_active($required_plugin)) {
             if ( isset($video['_cdp_video_videos_video_streaming_url']) )
               $vidObj->streamUrl[] = ['site' => 'youtube', 'url' => $video['_cdp_video_videos_video_streaming_url']];
             $vidObj->filetype = isset($fileinfo['fileformat'])?$fileinfo['fileformat']:'';
+            if ( array_key_exists('_cdp_video_videos_video_quality', $video) )
+              $vidObj->video_quality = $video['_cdp_video_videos_video_quality'];
 
             $size = new stdClass();
             if ( count($fileinfo) > 0 ) {
@@ -142,6 +144,7 @@ if (is_plugin_active($required_plugin)) {
     }
 
     private function get_srts( $post ) {
+      if ( !$post->_cdp_video_srts_srt ) return [];
       $filter = array_filter( $post->_cdp_video_srts_srt, function ( $srt ) {
         return !empty( $srt['_cdp_video_srts_srt_file'] );
       } );
@@ -149,6 +152,7 @@ if (is_plugin_active($required_plugin)) {
     }
 
     private function get_transcripts( $post ) {
+      if ( !$post->_cdp_video_transcripts_transcript ) return [];
       $filter = array_filter( $post->_cdp_video_transcripts_transcript, function ( $transcript ) {
         return ( !empty( $transcript['_cdp_video_transcripts_transcript_file'] )
           || !empty( $transcript['_cdp_video_transcripts_transcript_text'] ) );
@@ -167,6 +171,7 @@ if (is_plugin_active($required_plugin)) {
     }
 
     private function get_videos( $post ) {
+      if ( !$post->_cdp_video_videos_video ) return [];
       $filter = array_filter( $post->_cdp_video_videos_video, function ( $video ) {
         return ( !empty( $video['_cdp_video_videos_video_file'] )
           || !empty( $video['_cdp_video_videos_video_streaming_url'] ) );
@@ -175,6 +180,7 @@ if (is_plugin_active($required_plugin)) {
     }
     
     private function get_headers( $post ) {
+      if ( !$post->_cdp_video_headers ) return [];
       $filter = array_filter( $post->_cdp_video_headers, function ( $header ) {
         return ( !empty( $header['_cdp_video_headers_title'] )
          || !empty( $header['_cdp_video_headers_description'] ) );


### PR DESCRIPTION
Added dropdown for video quality.
Added REST property for video quality (when present to maintain backwards compatability).
Also added checks for empty values on the get srts/transcripts/videos/headers functions.